### PR TITLE
Added support for http2 and TLSv1.3 directive

### DIFF
--- a/edit_server.cgi
+++ b/edit_server.cgi
@@ -100,6 +100,7 @@ if ($access{'edit'}) {
 					$text{'server_port'},
 					$text{'server_default'},
 					$text{'server_ssl'},
+					$text{'server_http2'},
 					$text{'server_ipv6'} ], 100);
 	my $i = 0;
 	my @tds = ( "valign=top", "valign=top", "valign=top",
@@ -107,13 +108,16 @@ if ($access{'edit'}) {
 	foreach my $l (@listen, { 'words' => [ ] }) {
 		my @w = @{$l->{'words'}};
 		my ($ip, $port) = @w ? &split_ip_port(shift(@w)) : ( );
-		my ($default, $ssl, $ipv6) = (0, 0, "");
+		my ($default, $ssl, $http2, $ipv6) = (0, 0, 0, "");
 		foreach my $w (@w) {
 			if ($w eq "default" || $w eq "default_server") {
 				$default = 1;
 				}
 			elsif ($w eq "ssl") {
 				$ssl = 1;
+				}
+			elsif ($w eq "http2") {
+				$http2 = 1;
 				}
 			elsif ($w =~ /^ipv6only=(\S+)/) {
 				$ipv6 = lc($1);
@@ -133,6 +137,8 @@ if ($access{'edit'}) {
 			&ui_select("default_$i", $default,
 			   [ [ 0, $text{'no'} ], [ 1, $text{'yes'} ] ]),
 			&ui_select("ssl_$i", $ssl,
+			   [ [ 0, $text{'no'} ], [ 1, $text{'yes'} ] ]),
+			&ui_select("http2_$i", $http2,
 			   [ [ 0, $text{'no'} ], [ 1, $text{'yes'} ] ]),
 			&ui_select("ipv6_$i", $ipv6,
 			   [ [ "", $text{'server_auto'} ],

--- a/edit_ssl.cgi
+++ b/edit_ssl.cgi
@@ -25,7 +25,7 @@ print &nginx_opt_input("ssl_certificate_key", $server, 50, $text{'ssl_file'},
 print &nginx_opt_input("ssl_ciphers", $server, 30, $text{'ssl_clist'});
 
 print &nginx_multi_input("ssl_protocols", $server,
-			 [ "SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2" ]);
+			 [ "SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" ]);
 
 print &ui_table_end();
 print &ui_form_end([ [ undef, $text{'save'} ] ]);

--- a/lang/en
+++ b/lang/en
@@ -158,6 +158,7 @@ server_ip=IP address
 server_port=Port number
 server_default=Default host?
 server_ssl=SSL mode?
+server_http2=HTTP2 mode?
 server_ipv6=IPv6 only?
 server_ipany=Any IPv4 address
 server_ip6any=Any IPv6 address

--- a/lang/fr.auto
+++ b/lang/fr.auto
@@ -149,6 +149,7 @@ server_ip=adresse IP
 server_port=Numéro de port
 server_default=Hôte par défaut?
 server_ssl=Mode SSL?
+server_http2=Mode HTTP2?
 server_ipv6=IPv6 uniquement?
 server_ipany=N'importe quelle adresse IPv4
 server_ip6any=N'importe quelle adresse IPv6

--- a/lang/nl
+++ b/lang/nl
@@ -149,6 +149,7 @@ server_ip=IP adres
 server_port=Poort nummer
 server_default=Standaard host?
 server_ssl=SSL mode?
+server_http2=HTTP2 mode?
 server_ipv6=Alleen IPv6?
 server_ipany=Ieder IPv4 adres
 server_ip6any=Ieder IPv6 adres

--- a/lang/tr.auto
+++ b/lang/tr.auto
@@ -149,6 +149,7 @@ server_ip=IP adresi
 server_port=Port numarası
 server_default=Varsayılan ana makine?
 server_ssl=SSL modu?
+server_http2=HTTP2 modu?
 server_ipv6=Sadece IPv6 mı?
 server_ipany=Herhangi bir IPv4 adresi
 server_ip6any=Herhangi bir IPv6 adresi

--- a/nginx-directives
+++ b/nginx-directives
@@ -263,7 +263,7 @@ mail_ssl	ssl_certificate	cert.pem	mail,server
 mail_ssl	ssl_certificate_key	cert.pem	mail,server
 mail_ssl	ssl_ciphers	ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP	mail,server
 mail_ssl	ssl_prefer_server_ciphers	off	mail,server
-mail_ssl	ssl_protocols	SSLv2 SSLv3 TLSv1	mail,server
+mail_ssl	ssl_protocols	SSLv2 SSLv3 TLSv1 TLSv1.1 TLSv1.2 TLSv1.3	mail,server
 mail_ssl	ssl_session_cache	builtin:20480	mail,server
 mail_ssl	ssl_session_timeout	5m	mail,server
 mail_ssl	starttls	off	mail,server
@@ -275,7 +275,7 @@ http_ssl	ssl_dhparam	none	http,server
 http_ssl	ssl_ciphers	ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP	http,server
 http_ssl	ssl_crl	none	http,server
 http_ssl	ssl_prefer_server_ciphers	off	http,server
-http_ssl	ssl_protocols	SSLv2 SSLv3 TLSv1	http,server
+http_ssl	ssl_protocols	TLSv1 TLSv1.1 TLSv1.2 TLSv1.3	http,server
 http_ssl	ssl_verify_client	off	http,server
 http_ssl	ssl_verify_depth	1	http,server
 http_ssl	ssl_session_cache	off	http,server

--- a/save_server.cgi
+++ b/save_server.cgi
@@ -134,6 +134,9 @@ else {
 		if ($in{"ssl_$i"}) {
 			push(@words, "ssl");
 			}
+		if ($in{"http2_$i"}) {
+			push(@words, "http2");
+			}
 		if ($in{"ipv6_$i"}) {
 			push(@words, "ipv6only=".$in{"ipv6_$i"});
 			}


### PR DESCRIPTION
http2 has been supported for a long time already, where nghttp2 package is installed (Could be good to document somewhere?). The patch adds relevant configuration (https://prnt.sc/s9nzsp), and adds http2 to listen directive if enabled.

TLSv1.3 is also supported in latest stable nginx versions, so i added it to configuration as well.  

I tested both on my production server, ubuntu 18.04, and works without problem.

Resolves #13 
