### PR TITLE
Nginx improvements

### DIFF
--- a/virtual_feature.pl
+++ b/virtual_feature.pl
@@ -272,9 +272,12 @@ if (!$d->{'alias'}) {
 		     'words' => [ '~', '\.php(/|$)' ],
 		     'type' => 1,
 		     'members' => [
-			{ 'name' => 'try_files',
-			  'words' => [ '$uri', '$fastcgi_script_name', '=404' ],
-			},
+				{ 'name' => 'try_files',
+				  'words' => [ '$uri', '$fastcgi_script_name', '=404' ],
+				},
+				{ 'name' => 'default_type',
+				  'words' => [ 'application/x-httpd-php' ],
+				}
 		     ],
 		   };
 	&save_directive($server, [ ], [ $ploc ]);
@@ -1274,16 +1277,19 @@ if ($port) {
 	# Update the port in the config, if changed
 	if (!$loc) {
 		&lock_file($server->{'file'});
-		$loc = { 'name' => 'location',
-			 'words' => [ '~', '\.php(/|$)' ],
-			 'type' => 1,
-			 'members' => [
-			    { 'name' => 'try_files',
-			      'words' => [ '$uri', '$fastcgi_script_name',
-					   '=404' ],
-			    },
-			 ],
-		       };
+			$loc =
+			   { 'name' => 'location',
+				'words' => [ '~', '\.php(/|$)' ],
+				'type' => 1,
+				'members' => [
+					{ 'name' => 'default_type',
+					  'words' => [ 'application/x-httpd-php' ],
+					},
+					{ 'name' => 'try_files',
+					  'words' => [ '$uri', '$fastcgi_script_name', '=404' ],
+					},
+				  ],
+			   };
 		&save_directive($server, [ ], [ $loc ]);
 		&flush_file_lines($server->{'file'});
 		&unlock_file($server->{'file'});
@@ -1300,7 +1306,20 @@ elsif ($mode eq 'none') {
 	# Remove the location block
 	if ($loc) {
 		&lock_file($server->{'file'});
-		&save_directive($server, [ $loc ], [ ]);
+		my $locdeftype =
+		   { 'name' => 'location',
+			'words' => [ '~', '\.php(/|$)' ],
+			'type' => 1,
+			'members' => [
+				{ 'name' => 'default_type',
+				  'words' => [ 'text/plain' ],
+				},
+				{ 'name' => 'try_files',
+				  'words' => [ '$uri', '$fastcgi_script_name', '=404' ],
+				},
+			],
+		   };
+		&save_directive($server, [ $loc ], [ $locdeftype ]);
 		&flush_file_lines($server->{'file'});
 		&unlock_file($server->{'file'});
 		&virtual_server::register_post_action(\&print_apply_nginx);


### PR DESCRIPTION
Jamie, I was running more tests today on Nginx module and found few bugs:

  1. When PHP execution mode is set to `Disabled`, PHP files where downloaded instead of shown as text due to incorrect mime type. Fixed on this commit in this PR - https://github.com/virtualmin/virtualmin-nginx/commit/cf6a0ece77bfbc43eeae2b1759c0d9b82fb8290e
  2. Even though FCGIWrap `systemd` unit is setup correctly, the scripts are not executed (i.e. under `/cgi-bin` directory) and an error always displayed:
     <img width="625" alt="image" src="https://user-images.githubusercontent.com/4426533/191117920-dc6b91eb-379d-4429-8fb4-55e2894883ed.png">
  3. If a template has `Disabled` set for PHP execution mode then still a newly created website has `FCGId` setup by default (when should be `Disabled` as defined on the template)

Can you please pull this branch and check in a fix for `#2` and `#3` please? Also, check if `#1` looks good to you as it works perfectly fine for me.