### PR TITLE
Fix virtualmin-nginx to create the php symlink like the web module

### DIFF
--- a/virtual_feature.pl
+++ b/virtual_feature.pl
@@ -1441,6 +1441,8 @@ else {
 		}
 	}
 
+&virtual_server::create_php_bin_links($d, $mode);
+
 return undef;
 }
 


### PR DESCRIPTION
As part of [virtualmin-gpl#520](https://github.com/virtualmin/virtualmin-gpl/issues/520), there were [changes](https://github.com/virtualmin/virtualmin-gpl/commit/75364c97290423c1c0548abf613b95491a13815c) introduced to link `bin/php` in the home folder of the account to the PHP CLI for the primary version.

While that change is working for the `web` module, it is not working for `virtualmin-nginx`, this change closes the gap and brings the same functionality to `virtualmin-nginx`.