### PR TITLE
Listen to IPv6 when not writing IP address

### DIFF
--- a/virtual_feature.pl
+++ b/virtual_feature.pl
@@ -161,6 +161,9 @@ if (!$d->{'alias'}) {
 		push(@{$server->{'members'}},
 			{ 'name' => 'listen',
 			  'words' => [ $d->{'web_port'} ] });
+		push(@{$server->{'members'}},
+			{ 'name' => 'listen',
+			'words' => [ '[::]:'. $d->{'web_port'} ] });
 		}
 	else {
 		# Use IP and port


### PR DESCRIPTION
When `listen_mode=0`, currently it writes `listen` directive like this:

```
        listen 80;
```

That does not listen to IPv6. Additional directive must be written:

```
        listen 80;
        listen [::]:80;
```

Tested work in my local server.