### PR TITLE
Fix nginx SSL chain sync ordering

### DIFF
--- a/virtual_feature.pl
+++ b/virtual_feature.pl
@@ -2428,12 +2428,15 @@ elsif ($mode eq 'key') {
 	}
 elsif ($mode eq 'ca') {
 	# Nginx needs cert and CA in the same file!
+	$d->{'ssl_chain'} = $file;
 	if ($file) {
 		# Always re-sync here because linkage may have changed
 		&virtual_server::sync_combined_ssl_cert($d);
 		&nginx::save_directive($server, "ssl_certificate", [ $d->{'ssl_combined'} ]);
 		}
 	else {
+		&virtual_server::sync_combined_ssl_cert($d)
+			if ($d->{'ssl_cert'} && $d->{'ssl_key'});
 		# Revert to just the cert file
 		&nginx::save_directive($server, "ssl_certificate", [ $d->{'ssl_cert'} ]);
 		}


### PR DESCRIPTION
Hey Jamie,

As discussed in [this private ticket](https://forum.virtualmin.com/t/ssl-renewal-misses-chain-in-combined-and-everything/137292).

This PR updates the domain `ssl_chain` value before rebuilding nginx combined SSL certificate files, so CA additions and removals are reflected immediately in `ssl.combined` and `ssl.everything`.

