### PR TITLE
Fix Nginx listeners for IPv6-only domains

### DIFF
--- a/virtual_feature.pl
+++ b/virtual_feature.pl
@@ -2807,20 +2807,16 @@ if ($old_ip && $old_ip ne $new_ip) {
 if ($oldd) {
 	my @listen = &nginx::find("listen", $server);
 	my @newlisten;
+	my $ip_specific = grep {
+		my $word = $_->{'words'}->[0];
+		($old_ip && $word =~ /^\Q$old_ip\E(?::\d+)?$/) ||
+			($old_ip6 &&
+			 $word =~ /^\[\Q$old_ip6\E\](?::\d+)?$/)
+		} @listen;
 	foreach my $l (@listen) {
 		my @words = @{$l->{'words'}};
-		if ($config{'listen_mode'} eq '0') {
-			# Convert IP-specific listeners to wildcard listeners
-			if ($words[0] =~ /^\d+(?:\.\d+){3}(?::(\d+))?$/) {
-				$words[0] = $1 || 80;
-				}
-			elsif ($words[0] =~ /^\[\S+\](?::(\d+))?$/) {
-				$words[0] = "[::]:".($1 || 80);
-				}
-			push(@newlisten, { 'words' => \@words });
-			}
-		elsif ($old_ip &&
-		       $words[0] =~ /^\Q$old_ip\E(?::(\d+))?$/) {
+		if ($old_ip &&
+		    $words[0] =~ /^\Q$old_ip\E(?::(\d+))?$/) {
 			# Change or remove an old IPv4-specific listener
 			if ($new_ip) {
 				my $port = $1 || 80;
@@ -2839,64 +2835,48 @@ if ($oldd) {
 				push(@newlisten, { 'words' => \@words });
 				}
 			}
-		elsif ($words[0] =~ /^(\d+)$/) {
-			# Convert a wildcard IPv4 listener to this domain's IP
-			if ($new_ip) {
-				$words[0] = $new_ip.
-					($1 == 80 ? "" : ":".$1);
-				push(@newlisten, { 'words' => \@words });
-				}
-			}
-		elsif ($words[0] =~ /^\[::\](?::(\d+))?$/) {
-			# Convert a wildcard IPv6 listener to this domain's IP
-			if ($new_ip6) {
-				my $port = $1 || 80;
-				$words[0] = "[".$new_ip6."]".
-					($port == 80 ? "" : ":".$port);
-				push(@newlisten, { 'words' => \@words });
-				}
-			}
 		else {
 			# Listen directive is fine, keep as-is
 			push(@newlisten, { 'words' => \@words });
 			}
 		}
 
-	# Normalization can collapse multiple listeners into the same directive
+	# Address replacement can collapse multiple listeners into one
 	my %seen;
 	@newlisten = grep {
 		!$seen{join("\0", @{$_->{'words'}})}++
 		} @newlisten;
 
-	# Ensure that both configured address families have an HTTP listener
-	my $portstr = $d->{'web_port'} == 80 ? '' : ':'.$d->{'web_port'};
-	my $want_ip = $config{'listen_mode'} eq '0' ? $d->{'web_port'} :
-		      $new_ip ? $new_ip.$portstr : "";
-	my $want_ip6 = $config{'listen_mode'} eq '0' ?
-		       "[::]:".$d->{'web_port'} :
-		       $new_ip6 ? "[".$new_ip6."]".$portstr : "";
-	foreach my $want ($want_ip, $want_ip6) {
-		if ($want &&
-		    !grep { $_->{'words'}->[0] eq $want } @newlisten) {
-			push(@newlisten, { 'words' => [ $want ] });
-			}
-		}
-
-	# Do the same for HTTPS, preserving the backed-up SSL options
-	my ($ssl) = grep {
-		&indexof('ssl', @{$_->{'words'}}) >= 0
-		} @listen;
-	if ($ssl) {
-		my $sslport = $d->{'web_sslport'} || 443;
-		my @wantssl = $config{'listen_mode'} eq '0' ?
-			      ($sslport, "[::]:".$sslport) :
-			      ($new_ip ? $new_ip.":".$sslport : "",
-			       $new_ip6 ? "[".$new_ip6."]:".$sslport : "");
-		foreach my $want (@wantssl) {
+	# For an IP-specific backup, ensure that both configured address
+	# families retain HTTP and HTTPS listeners.  Wildcard backups keep
+	# their original listener style, regardless of the local listen_mode.
+	if ($ip_specific) {
+		my $portstr = $d->{'web_port'} == 80 ? '' :
+			      ':'.$d->{'web_port'};
+		foreach my $want (
+			$new_ip ? $new_ip.$portstr : "",
+			$new_ip6 ? "[".$new_ip6."]".$portstr : "") {
 			if ($want &&
 			    !grep { $_->{'words'}->[0] eq $want } @newlisten) {
-				push(@newlisten,
-				     &clone_ssl_listen_for_address($ssl, $want));
+				push(@newlisten, { 'words' => [ $want ] });
+				}
+			}
+
+		my ($ssl) = grep {
+			&indexof('ssl', @{$_->{'words'}}) >= 0
+			} @listen;
+		if ($ssl) {
+			my $sslport = $d->{'web_sslport'} || 443;
+			foreach my $want (
+				$new_ip ? $new_ip.":".$sslport : "",
+				$new_ip6 ? "[".$new_ip6."]:".$sslport : "") {
+				if ($want &&
+				    !grep { $_->{'words'}->[0] eq $want }
+					  @newlisten) {
+					push(@newlisten,
+					     &clone_ssl_listen_for_address(
+						     $ssl, $want));
+					}
 				}
 			}
 		}

--- a/virtual_feature.pl
+++ b/virtual_feature.pl
@@ -373,6 +373,18 @@ else {
 	}
 }
 
+# clone_ssl_listen_for_address(&listen, address:port)
+# Clone an SSL listener without options that are specific to its old address
+sub clone_ssl_listen_for_address
+{
+my ($ssl, $address) = @_;
+my $def = &nginx::get_default_server_param();
+my @words = grep { $_ ne $def && $_ !~ /^ipv6only=/ }
+		  @{$ssl->{'words'}};
+$words[0] = $address;
+return { 'words' => \@words };
+}
+
 # feature_modify(&domain, &old-domain)
 # Change the Nginx domain name or home directory
 sub feature_modify
@@ -464,8 +476,22 @@ if (!$d->{'alias'}) {
 				push(@newlisten, { 'words' => \@words });
 				}
 			}
-		if ($new_ip && !$old_ip) {
-			push(@newlisten, { 'words' => [ $new_ip ] });
+		if ($new_ip && !$old_ip && $config{'listen_mode'} ne '0') {
+			my $portstr = $d->{'web_port'} == 80 ? ''
+							     : ':'.$d->{'web_port'};
+			push(@newlisten,
+			     { 'words' => [ $new_ip.$portstr ] });
+			my ($ssl) = grep {
+				&indexof('ssl', @{$_->{'words'}}) >= 0
+				} @listen;
+			if ($ssl) {
+				my @sslwords = @{$ssl->{'words'}};
+				my ($sslport) =
+					$sslwords[0] =~ /(?:^|:)(\d+)$/;
+				push(@newlisten, &clone_ssl_listen_for_address(
+					$ssl, $new_ip.":".
+					($sslport || $d->{'web_sslport'} || 443)));
+				}
 			}
 		&nginx::save_directive($server, "listen", \@newlisten);
 
@@ -483,6 +509,7 @@ if (!$d->{'alias'}) {
 		&$virtual_server::second_print(
 			$virtual_server::text{'setup_done'});
 		$changed++;
+		$need_restart++;
 		}
 
 	# Update IPv6 address (or add or remove)
@@ -521,8 +548,22 @@ if (!$d->{'alias'}) {
 				push(@newlisten, { 'words' => \@w });
 				}
 			}
-		if ($new_ip6 && !$old_ip6) {
-			push(@newlisten, { 'words' => [ $new_ip6 ] });
+		if ($new_ip6 && !$old_ip6 && $config{'listen_mode'} ne '0') {
+			my $portstr = $d->{'web_port'} == 80 ? ''
+							     : ':'.$d->{'web_port'};
+			push(@newlisten,
+			     { 'words' => [ $new_ip6.$portstr ] });
+			my ($ssl) = grep {
+				&indexof('ssl', @{$_->{'words'}}) >= 0
+				} @listen;
+			if ($ssl) {
+				my @sslwords = @{$ssl->{'words'}};
+				my ($sslport) =
+					$sslwords[0] =~ /(?:^|:)(\d+)$/;
+				push(@newlisten, &clone_ssl_listen_for_address(
+					$ssl, $new_ip6.":".
+					($sslport || $d->{'web_sslport'} || 443)));
+				}
 			}
 		&nginx::save_directive($server, "listen", \@newlisten);
 		&$virtual_server::second_print(
@@ -544,14 +585,15 @@ if (!$d->{'alias'}) {
 		my @newlisten;
 		foreach my $l (@listen) {
 			my @w = @{$l->{'words'}};
-			my $p = $w[0] =~ /:(\d+)$/ ? $1 : 80;
-			if ($p == $oldd->{'web_port'}) {
+			if ($w[0] =~ /^(\d+)$/) {
+				$w[0] = $d->{'web_port'}
+					if ($1 == $oldd->{'web_port'});
+				}
+			elsif (($w[0] =~ /:(\d+)$/ ? $1 : 80) ==
+			       $oldd->{'web_port'}) {
 				$w[0] =~ s/:\d+$//;
 				$w[0] .= ":".$d->{'web_port'}
 					if ($d->{'web_port'} != 80);
-				}
-			elsif ($w[0] eq $oldd->{'web_port'}) {
-				$w[0] = $d->{'web_port'};
 				}
 			push(@newlisten, { 'words' => \@w });
 			}
@@ -2765,36 +2807,98 @@ if ($old_ip && $old_ip ne $new_ip) {
 if ($oldd) {
 	my @listen = &nginx::find("listen", $server);
 	my @newlisten;
-	my ($found, $found6);
 	foreach my $l (@listen) {
 		my @words = @{$l->{'words'}};
-		if ($words[0] =~ /^([0-9\.]+)(:\d+)?$/ && $1 eq $old_ip) {
-			# Change old IPv4 to new IPv4, if there is one
-			if ($new_ip) {
-				$words[0] = $new_ip.$2;
-				push(@newlisten, { 'words' => \@words });
+		if ($config{'listen_mode'} eq '0') {
+			# Convert IP-specific listeners to wildcard listeners
+			if ($words[0] =~ /^\d+(?:\.\d+){3}(?::(\d+))?$/) {
+				$words[0] = $1 || 80;
 				}
-			$found++;
+			elsif ($words[0] =~ /^\[\S+\](?::(\d+))?$/) {
+				$words[0] = "[::]:".($1 || 80);
+				}
+			push(@newlisten, { 'words' => \@words });
 			}
-		elsif ($words[0] =~ /^\[(\S+)\](:\d+)?$/ && $1 eq $old_ip6) {
-			# Change old IPv6 to new IPv6, if there is one
-			if ($new_ip6) {
-				$words[0] = "[".$new_ip6."]".$2;
+		elsif ($old_ip &&
+		       $words[0] =~ /^\Q$old_ip\E(?::(\d+))?$/) {
+			# Change or remove an old IPv4-specific listener
+			if ($new_ip) {
+				my $port = $1 || 80;
+				$words[0] = $new_ip.
+					($port == 80 ? "" : ":".$port);
 				push(@newlisten, { 'words' => \@words });
 				}
-			$found6++;
+			}
+		elsif ($old_ip6 &&
+		       $words[0] =~ /^\[\Q$old_ip6\E\](?::(\d+))?$/) {
+			# Change or remove an old IPv6-specific listener
+			if ($new_ip6) {
+				my $port = $1 || 80;
+				$words[0] = "[".$new_ip6."]".
+					($port == 80 ? "" : ":".$port);
+				push(@newlisten, { 'words' => \@words });
+				}
+			}
+		elsif ($words[0] =~ /^(\d+)$/) {
+			# Convert a wildcard IPv4 listener to this domain's IP
+			if ($new_ip) {
+				$words[0] = $new_ip.
+					($1 == 80 ? "" : ":".$1);
+				push(@newlisten, { 'words' => \@words });
+				}
+			}
+		elsif ($words[0] =~ /^\[::\](?::(\d+))?$/) {
+			# Convert a wildcard IPv6 listener to this domain's IP
+			if ($new_ip6) {
+				my $port = $1 || 80;
+				$words[0] = "[".$new_ip6."]".
+					($port == 80 ? "" : ":".$port);
+				push(@newlisten, { 'words' => \@words });
+				}
 			}
 		else {
 			# Listen directive is fine, keep as-is
 			push(@newlisten, { 'words' => \@words });
 			}
 		}
+
+	# Normalization can collapse multiple listeners into the same directive
+	my %seen;
+	@newlisten = grep {
+		!$seen{join("\0", @{$_->{'words'}})}++
+		} @newlisten;
+
+	# Ensure that both configured address families have an HTTP listener
 	my $portstr = $d->{'web_port'} == 80 ? '' : ':'.$d->{'web_port'};
-	if ($new_ip && !$found) {
-		push(@newlisten, { 'words' => [ $new_ip.$portstr ] });
+	my $want_ip = $config{'listen_mode'} eq '0' ? $d->{'web_port'} :
+		      $new_ip ? $new_ip.$portstr : "";
+	my $want_ip6 = $config{'listen_mode'} eq '0' ?
+		       "[::]:".$d->{'web_port'} :
+		       $new_ip6 ? "[".$new_ip6."]".$portstr : "";
+	foreach my $want ($want_ip, $want_ip6) {
+		if ($want &&
+		    !grep { $_->{'words'}->[0] eq $want } @newlisten) {
+			push(@newlisten, { 'words' => [ $want ] });
+			}
 		}
-	if ($new_ip6 && !$found6) {
-		push(@newlisten, { 'words' => [ "[".$new_ip6."]".$portstr ] });
+
+	# Do the same for HTTPS, preserving the backed-up SSL options
+	my ($ssl) = grep {
+		&indexof('ssl', @{$_->{'words'}}) >= 0
+		} @listen;
+	if ($ssl) {
+		my $sslport = $d->{'web_sslport'} || 443;
+		my @wantssl = $config{'listen_mode'} eq '0' ?
+			      ($sslport, "[::]:".$sslport) :
+			      ($new_ip ? $new_ip.":".$sslport : "",
+			       $new_ip6 ? "[".$new_ip6."]:".$sslport : "");
+		foreach my $want (@wantssl) {
+			if ($want &&
+			    !grep { $_->{'words'}->[0] eq $want } @newlisten) {
+				push(@newlisten,
+				     &clone_ssl_listen_for_address($ssl, $want));
+				}
+			}
 		}
 	&nginx::save_directive($server, "listen", \@newlisten);
 	}
@@ -2822,7 +2926,7 @@ if ($oldd && $oldd->{'nginx_php_port'} ne $d->{'nginx_php_port'}) {
 
 &nginx::flush_config_file_lines();
 &nginx::unlock_all_config_files();
-&virtual_server::register_post_action(\&print_apply_nginx);
+&virtual_server::register_post_action(\&print_apply_nginx, $oldd ? 1 : 0);
 &$virtual_server::second_print($virtual_server::text{'setup_done'});
 
 # Correct system-specific entries in PHP config files


### PR DESCRIPTION
Hey Jamie!

As you requested, I've included my reverted changes in the PR.

This PR preserves HTTP and HTTPS listeners when IP families are added, removed, or restored.

It also normalizes wildcard listeners, and retains SSL ports, and options safely, and uses the existing full-restart flag when restored listener sockets can change.