### PR TITLE
Fix Nginx listener updates in wildcard mode

### DIFF
--- a/virtual_feature.pl
+++ b/virtual_feature.pl
@@ -495,7 +495,8 @@ if (!$d->{'alias'}) {
 		foreach my $l (@listen) {
 			my @w = @{$l->{'words'}};
 			my $p = $w[0] =~ /:(\d+)$/ ? $1 : 80;
-			if ($p == $oldd->{'web_port'}) {
+			if ($p == $oldd->{'web_port'} &&
+			    $w[0] !~ /^\d+$/) {
 				$w[0] =~ s/:\d+$//;
 				$w[0] .= ":".$d->{'web_port'}
 					if ($d->{'web_port'} != 80);
@@ -3788,7 +3789,7 @@ foreach my $l (@listen) {
 		push(@newlisten, { 'words' => \@words });
 		}
 	}
-if ($new_ip && !$old_ip) {
+if ($new_ip && !$old_ip && $config{'listen_mode'} ne '0') {
 	# Need to add an IP address
 	my $port = $d->{'web_port'} == 80 ? '' : ':'.$d->{'web_port'};
 	my $sslport = ':'.$d->{'web_sslport'};


### PR DESCRIPTION
Hey Jamie!

This PR fixes two issues when Nginx uses wildcard listeners:

- Prevent port-only directives such as `listen 80;` from becoming invalid `listen 80:8080;`.

- Avoid adding IP-specific listeners when `listen_mode=0`.

Tested https://github.com/virtualmin/virtualmin-gpl/commit/1cfaf1c46322ad111a7eb43d53744855e5010867 on Debian 12 with IPv6-only and dual-stack domains in both wildcard and IP-specific modes. Port changes, IPv4 additions, HTTP, HTTPS, Nginx restarts, and `nginx -t` all passed.

Run it as root on an Nginx test host:

```bash
virtualmin functional-test \
  --test nginxlisten \
  --web-feature virtualmin-nginx \
  --ssl-feature virtualmin-nginx-ssl \
  --domain nginx-listener-test.debian12-pro.virtualmin.dev \
  --max-output 6000
```

With the fix, the result should end with:

```text
.. 10 OK, 0 FAILED, 0 SKIPPED
```