### PR TITLE
Fix to set X-Forwarded-Proto for nginx proxy backends

### DIFF
--- a/virtual_feature.pl
+++ b/virtual_feature.pl
@@ -2201,6 +2201,8 @@ if ($url) {
 	       'words' => [ 'Connection', 'Upgrade' ], },
 	     { 'name' => 'proxy_set_header',
 	       'words' => [ 'Host', '$host' ], },
+	     { 'name' => 'proxy_set_header',
+	       'words' => [ 'X-Forwarded-Proto', '$scheme' ], },
 	    );
 	}
 $balancer->{'location'} = $l;


### PR DESCRIPTION
Hey Jamie,

This PR ensures apps behind Virtualmin-managed Nginx proxies receive the correct X-Forwarded-Proto` value for HTTP and HTTPS requests, this time for both direct and load-balanced backends.

Closes https://github.com/virtualmin/virtualmin-gpl/issues/1260.